### PR TITLE
refactor: move inline styles into css classes

### DIFF
--- a/css/aladin.css
+++ b/css/aladin.css
@@ -51,11 +51,15 @@
 }
 
 /* External toolbar (you can place your own buttons) ---------------------- */
-.hubble-skin .al-toolbar { display:flex; gap:8px; align-items:center; padding:8px; 
+.hubble-skin .al-toolbar { display:flex; gap:8px; align-items:center; padding:8px;
   background: rgba(14,21,51,.65); border:1px solid var(--al-border); border-radius: 10px; }
 .hubble-skin .al-btn { appearance:none; border:1px solid var(--al-border); background:linear-gradient(180deg,#111933,#0b1026); color:var(--al-text);
   padding:6px 10px; border-radius:8px; font:12px/1 system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif; cursor:pointer; }
 .hubble-skin .al-btn:hover { border-color: var(--al-ring); }
+
+.al-select { padding:6px 10px; }
+.al-select-wide { min-width:220px; }
+.aladin-map { height:420px; border:1px solid rgba(255,255,255,0.12); border-radius:12px; overflow:hidden; }
 
 /* Legend chips ------------------------------------------------------------ */
 .hubble-skin .al-legend { position:absolute; left:12px; bottom:10px; z-index: 1000; display:flex; gap:8px; align-items:center; }

--- a/css/main.css
+++ b/css/main.css
@@ -30,6 +30,8 @@
         #chat-container::-webkit-scrollbar-track, #chat-history::-webkit-scrollbar-track { background-color: #1a202c; }
         .user-bubble { background: linear-gradient(135deg, #3B82F6, #2563EB); color: white; align-self: flex-end; box-shadow: 0 4px 20px rgba(59, 130, 246, 0.25); }
         .assistant-bubble { background: rgba(55, 65, 81, 0.9); color: #E5E7EB; align-self: flex-start; }
+        .chat-wrapper { height: 90vh; }
+        .chat-header { height: 70px; }
         .mic-wrapper { position: relative; display: flex; justify-content: center; align-items: center; }
         .mic-wrapper::before { content: ''; position: absolute; width: 110px; height: 110px; background: radial-gradient(circle, rgba(0, 191, 255, 0.35) 0%, rgba(0, 191, 255, 0) 65%); border-radius: 50%; z-index: 0; animation: aurora 5s infinite linear; }
         #mic-btn { z-index: 1; animation: breathe 3s infinite ease-in-out; }

--- a/index.html
+++ b/index.html
@@ -168,8 +168,8 @@
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
         </button>
         <div class="flex items-center justify-center min-h-screen text-white p-4">
-            <div class="w-full max-w-2xl mx-auto glass-container rounded-2xl shadow-2xl flex flex-col p-6" style="height: 90vh;">
-                <div class="relative text-center border-b border-gray-700/50 pb-2 mb-4" style="height: 70px;">
+            <div class="w-full max-w-2xl mx-auto glass-container rounded-2xl shadow-2xl flex flex-col p-6 chat-wrapper">
+                <div class="relative text-center border-b border-gray-700/50 pb-2 mb-4 chat-header">
                     <p id="status" class="text-sm text-cyan-400 h-5 transition-all duration-300 mt-1">Konuşmak için mikrofon simgesine dokunun</p>
                     <button id="clear-chat-btn" title="Sohbeti Temizle" class="absolute top-1 right-0 text-gray-500 hover:text-white transition-colors p-2">
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
@@ -194,8 +194,8 @@
     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
   </button>
   <div class="flex items-center justify-center min-h-screen text-white p-4">
-    <div class="w-full max-w-2xl mx-auto glass-container rounded-2xl shadow-2xl flex flex-col p-6" style="height: 90vh;">
-      <div class="relative text-center border-b border-gray-700/50 pb-2 mb-4" style="height: 70px;">
+    <div class="w-full max-w-2xl mx-auto glass-container rounded-2xl shadow-2xl flex flex-col p-6 chat-wrapper">
+      <div class="relative text-center border-b border-gray-700/50 pb-2 mb-4 chat-header">
         <p id="asistan-status" class="text-sm text-cyan-400 h-5 transition-all duration-300 mt-1">Konuşmak için mikrofon simgesine dokunun</p>
         <button id="asistan-clear-chat-btn" title="Sohbeti Temizle" class="absolute top-1 right-0 text-gray-500 hover:text-white transition-colors p-2">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
@@ -326,7 +326,7 @@
                   <button id="btnFullSky" class="al-btn">Full Sky</button>
                   <button id="btnOrion" class="al-btn">Orion</button>
                   <button id="btnClearExo" class="al-btn">Temizle</button>
-                  <select id="surveySelect" class="al-btn" style="padding:6px 10px">
+                  <select id="surveySelect" class="al-btn al-select">
                     <option value="P/DSS2/color" selected>DSS2</option>
                     <option value="P/SDSS9/color">SDSS9</option>
                     <option value="P/AllWISE/color">AllWISE</option>
@@ -339,11 +339,11 @@
                 <div class="al-toolbar glass">
                   <button id="tourPrev" class="al-btn">◀︎ Önceki</button>
                   <button id="tourNext" class="al-btn">Sonraki ▶︎</button>
-                  <select id="tourSelect" class="al-btn" style="padding:6px 10px; min-width: 220px"></select>
+                  <select id="tourSelect" class="al-btn al-select al-select-wide"></select>
                   <button id="tourPlay" class="al-btn">Oto Tur</button>
                 </div>
               </div>
-              <div id="aladin-map" class="al-host" style="height:420px;border:1px solid rgba(255,255,255,0.12);border-radius:12px;overflow:hidden">
+              <div id="aladin-map" class="al-host aladin-map">
                 <div class="al-legend">
                   <span class="al-pill"><span class="dot near"></span> Yakın</span>
                   <span class="al-pill"><span class="dot mid"></span> Orta</span>


### PR DESCRIPTION
## Summary
- move various inline styles in `index.html` into reusable CSS classes
- add chat layout utility classes for consistent heights
- add Aladin map and select styling classes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b55834d4bc8328a02098684911ab23