### PR TITLE
refactor: centralize default system prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
         </div>
     </div>
     </div>
-<script src="js/system-prompt-helpers.js"></script>
+<script type="module" src="js/system-prompt-helpers.js"></script>
     <!-- Tanılama / Ağ Hatası Yüzeyleme -->
 <script id="diagnostics">
 (function(){
@@ -1141,7 +1141,7 @@ function toggleMask(inputEl, btnEl){
     <script type="module" src="js/intro-animation.js"></script>
 <script src="js/kaira-debug-toggle.js"></script>
 <script src="js/form-input-safety.js"></script>
-<script src="js/default-system-prompt.js"></script>
+<script type="module" src="js/default-system-prompt.js"></script>
 <script type="module" src="js/main-controller.js"></script>
 </body>
 </html>

--- a/js/default-system-prompt.js
+++ b/js/default-system-prompt.js
@@ -1,20 +1,18 @@
-(function(){
-  // Varsayılan sistem promptu — boşsa bu doldurulur
-  const DEFAULT_SYSTEM_PROMPT = `Türkçe yanıt ver. Alaycı davran, ama aynı zamanda bilgilendirici ol, Üstten konuş, şakacı ol. Cevapların kısa ve öz olsun. Mizah kat. Gereksiz detaylardan kaçın. Cevapların 3 cümleyi geçmesin. Kullanıcıyı güldürmeye çalış.`;
+import { DEFAULT_SYSTEM_PROMPT } from './system-prompt-helpers.js';
 
-  function ensureDefaultSystemPrompt(){
-    const el = document.getElementById('system-prompt');
-    if (el && !el.value.trim()) el.value = DEFAULT_SYSTEM_PROMPT;
-  }
+// Varsayılan sistem promptu — boşsa bu doldurulur
+function ensureDefaultSystemPrompt(){
+  const el = document.getElementById('system-prompt');
+  if (el && !el.value.trim()) el.value = DEFAULT_SYSTEM_PROMPT;
+}
 
-  // Sayfa yüklenince ve sohbet görünümü seçilince doldur
-  document.addEventListener('DOMContentLoaded', ensureDefaultSystemPrompt);
-  const selectChat = document.getElementById('select-chat');
-  if (selectChat) selectChat.addEventListener('click', ensureDefaultSystemPrompt);
+// Sayfa yüklenince ve sohbet görünümü seçilince doldur
+document.addEventListener('DOMContentLoaded', ensureDefaultSystemPrompt);
+const selectChat = document.getElementById('select-chat');
+if (selectChat) selectChat.addEventListener('click', ensureDefaultSystemPrompt);
 
-  // Gönder'e basıldığında da boşsa otomatik doldur (capture=true: önce bizimki çalışır)
-  const sendBtn = document.getElementById('send-button');
-  if (sendBtn) sendBtn.addEventListener('click', function(){
-    ensureDefaultSystemPrompt();
-  }, true);
-})();
+// Gönder'e basıldığında da boşsa otomatik doldur (capture=true: önce bizimki çalışır)
+const sendBtn = document.getElementById('send-button');
+if (sendBtn) sendBtn.addEventListener('click', function(){
+  ensureDefaultSystemPrompt();
+}, true);

--- a/js/system-prompt-helpers.js
+++ b/js/system-prompt-helpers.js
@@ -1,135 +1,133 @@
-(function(){
-  // Görünmez varsayılan sistem promptu: kullanıcı alanını doldurmayız,
-  // sadece gönderim anında geçici olarak enjekte edip hemen geri boşaltırız.
-  const DEFAULT_SYSTEM_PROMPT = `Türkçe yanıt ver. Alaycı davran, ama aynı zamanda bilgilendirici ol, Üstten konuş, şakacı ol. Cevapların kısa ve öz olsun. Mizah kat. Gereksiz detaylardan kaçın. Cevapların 3 cümleyi geçmesin. Kullanıcıyı güldürmeye çalış.`;
+// Görünmez varsayılan sistem promptu: kullanıcı alanını doldurmayız,
+// sadece gönderim anında geçici olarak enjekte edip hemen geri boşaltırız.
+export const DEFAULT_SYSTEM_PROMPT = `Türkçe yanıt ver. Alaycı davran, ama aynı zamanda bilgilendirici ol, Üstten konuş, şakacı ol. Cevapların kısa ve öz olsun. Mizah kat. Gereksiz detaylardan kaçın. Cevapların 3 cümleyi geçmesin. Kullanıcıyı güldürmeye çalış.`;
 
-  function injectStealthDefaultOnce(){
-    const el = document.getElementById('system-prompt');
-    if (!el || el.value.trim()) return; // kullanıcı yazdıysa dokunma
-    el.dataset.kairaWasEmpty = '1';
-    el.value = DEFAULT_SYSTEM_PROMPT;   // sadece gönderim anında geçici yaz
-    // mikro-görevde geri boşalt
-    setTimeout(()=>{
-      if (el && el.dataset.kairaWasEmpty === '1') {
-        el.value = '';
-        delete el.dataset.kairaWasEmpty;
-      }
-    }, 0);
-  }
+function injectStealthDefaultOnce(){
+  const el = document.getElementById('system-prompt');
+  if (!el || el.value.trim()) return; // kullanıcı yazdıysa dokunma
+  el.dataset.kairaWasEmpty = '1';
+  el.value = DEFAULT_SYSTEM_PROMPT;   // sadece gönderim anında geçici yaz
+  // mikro-görevde geri boşalt
+  setTimeout(()=>{
+    if (el && el.dataset.kairaWasEmpty === '1') {
+      el.value = '';
+      delete el.dataset.kairaWasEmpty;
+    }
+  }, 0);
+}
 
-  function clearChatUI(){
+function clearChatUI(){
+  try {
+    // 1) Görünen konteynerleri boşalt
+    const hist = document.getElementById('chat-history');
+    if (hist) hist.innerHTML = '';
+    const hist2 = document.getElementById('chat-container');
+    if (hist2) hist2.innerHTML = '';
+
+    // Her ihtimale karşı sohbet balonlarını doğrudan temizle
+    document.querySelectorAll('#chat-view .chat-user-bubble, #chat-view .chat-assistant-bubble, #chat-view [data-chat-item]').forEach(function(el){ el.remove(); });
+
+    // 2) Hata/loader ve giriş alanını sıfırla
+    const err = document.getElementById('error-message');
+    if (err) { err.classList.add('hidden'); err.textContent = ''; }
+    const loader = document.getElementById('loader');
+    if (loader) loader.classList.add('hidden');
+    const userIn = document.getElementById('user-input');
+    if (userIn) userIn.value = '';
+
+    // 3) Bellekteki (JS) geçmiş yapılarını sıfırla (varsa)
     try {
-      // 1) Görünen konteynerleri boşalt
-      const hist = document.getElementById('chat-history');
-      if (hist) hist.innerHTML = '';
-      const hist2 = document.getElementById('chat-container');
-      if (hist2) hist2.innerHTML = '';
+      const g = window;
+      const CANDIDATES = ['conversation','messages','chatHistory','history','chatMessages','__kairaMessages','__chatCtx'];
+      CANDIDATES.forEach(function(k){
+        if (Array.isArray(g[k])) { g[k].length = 0; }
+        else if (g[k] && typeof g[k].clear === 'function') { try { g[k].clear(); } catch(_){} }
+        else if (g[k] && typeof g[k] === 'object') { try { Object.keys(g[k]).forEach(function(p){ delete g[k][p]; }); } catch(_){} }
+      });
+      // Yaygın custom temizleyiciler
+      if (typeof g.resetChat === 'function') { try { g.resetChat(); } catch(_){} }
+      if (typeof g.clearHistory === 'function') { try { g.clearHistory(); } catch(_){} }
+    } catch(_){ }
 
-      // Her ihtimale karşı sohbet balonlarını doğrudan temizle
-      document.querySelectorAll('#chat-view .chat-user-bubble, #chat-view .chat-assistant-bubble, #chat-view [data-chat-item]').forEach(function(el){ el.remove(); });
+    // 4) storage alanları (local + session) — chat/kaira içeriyorsa sil
+    try {
+      const nuke = function(storage){
+        const toDel = [];
+        for (let i = 0; i < storage.length; i++) {
+          const k = storage.key(i);
+          if (/chat|kaira/i.test(k)) toDel.push(k);
+        }
+        toDel.forEach(function(k){ try { storage.removeItem(k); } catch(_){} });
+      };
+      if (window.localStorage) nuke(window.localStorage);
+      if (window.sessionStorage) nuke(window.sessionStorage);
+    } catch(_){ }
 
-      // 2) Hata/loader ve giriş alanını sıfırla
-      const err = document.getElementById('error-message');
-      if (err) { err.classList.add('hidden'); err.textContent = ''; }
-      const loader = document.getElementById('loader');
-      if (loader) loader.classList.add('hidden');
-      const userIn = document.getElementById('user-input');
-      if (userIn) userIn.value = '';
-
-      // 3) Bellekteki (JS) geçmiş yapılarını sıfırla (varsa)
-      try {
-        const g = window;
-        const CANDIDATES = ['conversation','messages','chatHistory','history','chatMessages','__kairaMessages','__chatCtx'];
-        CANDIDATES.forEach(function(k){
-          if (Array.isArray(g[k])) { g[k].length = 0; }
-          else if (g[k] && typeof g[k].clear === 'function') { try { g[k].clear(); } catch(_){} }
-          else if (g[k] && typeof g[k] === 'object') { try { Object.keys(g[k]).forEach(function(p){ delete g[k][p]; }); } catch(_){} }
-        });
-        // Yaygın custom temizleyiciler
-        if (typeof g.resetChat === 'function') { try { g.resetChat(); } catch(_){} }
-        if (typeof g.clearHistory === 'function') { try { g.clearHistory(); } catch(_){} }
-      } catch(_){ }
-
-      // 4) storage alanları (local + session) — chat/kaira içeriyorsa sil
-      try {
-        const nuke = function(storage){
-          const toDel = [];
-          for (let i = 0; i < storage.length; i++) {
-            const k = storage.key(i);
-            if (/chat|kaira/i.test(k)) toDel.push(k);
-          }
-          toDel.forEach(function(k){ try { storage.removeItem(k); } catch(_){} });
-        };
-        if (window.localStorage) nuke(window.localStorage);
-        if (window.sessionStorage) nuke(window.sessionStorage);
-      } catch(_){ }
-
-      // 5) Sistem promptu kullanıcıya görünmesin (gizli varsayılanı temizle)
-      const sys = document.getElementById('system-prompt');
-      if (sys && sys.value && sys.value.trim() === DEFAULT_SYSTEM_PROMPT.trim()) sys.value = '';
-
-      // 6) Scroll tepeye
-      const wrap = document.getElementById('chat-view');
-      if (wrap && typeof wrap.scrollTo === 'function') wrap.scrollTo({ top: 0, behavior: 'smooth' });
-
-      // 7) Olay yayınla
-      document.dispatchEvent(new CustomEvent('kaira:chat-cleared', { detail: { source: 'clear-button' } }));
-
-      console.log('[Chat] cleared');
-    } catch(e){ console.warn('[Chat Clear] ', e); }
-  }
-
-  window.__kairaClearChat = clearChatUI;
-
-  function wipeSystemPromptOnEnterChat(){
-    // Evrensel Sohbet görünümü seçildiğinde textarea'yı boşalt
+    // 5) Sistem promptu kullanıcıya görünmesin (gizli varsayılanı temizle)
     const sys = document.getElementById('system-prompt');
-    if (sys && !sys.dataset.userTouched) sys.value = '';
+    if (sys && sys.value && sys.value.trim() === DEFAULT_SYSTEM_PROMPT.trim()) sys.value = '';
+
+    // 6) Scroll tepeye
+    const wrap = document.getElementById('chat-view');
+    if (wrap && typeof wrap.scrollTo === 'function') wrap.scrollTo({ top: 0, behavior: 'smooth' });
+
+    // 7) Olay yayınla
+    document.dispatchEvent(new CustomEvent('kaira:chat-cleared', { detail: { source: 'clear-button' } }));
+
+    console.log('[Chat] cleared');
+  } catch(e){ console.warn('[Chat Clear] ', e); }
+}
+
+window.__kairaClearChat = clearChatUI;
+
+function wipeSystemPromptOnEnterChat(){
+  // Evrensel Sohbet görünümü seçildiğinde textarea'yı boşalt
+  const sys = document.getElementById('system-prompt');
+  if (sys && !sys.dataset.userTouched) sys.value = '';
+}
+
+function wireUp(){
+  // 1) Delegated click: DOM tekrar oluşturulsa bile çalışsın (capture)
+  document.addEventListener('click', function(ev){
+    const target = ev.target;
+    if (!target || typeof target.closest !== 'function') return;
+    // Gönder butonu
+    if (target.closest('#send-button')) {
+      injectStealthDefaultOnce();
+    }
+    // Sohbeti temizle
+    if (target.closest('#clear-chat')) {
+      ev.preventDefault();
+      clearChatUI();
+    }
+    // Seçim ekranından Evrensel Sohbet'e girişte promptu boşalt
+    if (target.closest('#select-chat')) {
+      wipeSystemPromptOnEnterChat();
+    }
+  }, true);
+
+  // 2) Hedef butona doğrudan dinleyici ekle (stopImmediatePropagation olsa bile capture ile yakalarız)
+  const clearBtn = document.getElementById('clear-chat');
+  if (clearBtn) {
+    clearBtn.setAttribute('type','button');
+    clearBtn.addEventListener('click', function(e){ e.preventDefault(); clearChatUI(); }, true); // capture=true
   }
 
-  function wireUp(){
-    // 1) Delegated click: DOM tekrar oluşturulsa bile çalışsın (capture)
-    document.addEventListener('click', function(ev){
-      const target = ev.target;
-      if (!target || typeof target.closest !== 'function') return;
-      // Gönder butonu
-      if (target.closest('#send-button')) {
+  // Enter (Shift'siz) ile gönderimler için de koruma
+  const input = document.getElementById('user-input');
+  if (input) {
+    input.addEventListener('keydown', function(ev){
+      if (ev.key === 'Enter' && !ev.shiftKey) {
         injectStealthDefaultOnce();
       }
-      // Sohbeti temizle
-      if (target.closest('#clear-chat')) {
-        ev.preventDefault();
-        clearChatUI();
-      }
-      // Seçim ekranından Evrensel Sohbet'e girişte promptu boşalt
-      if (target.closest('#select-chat')) {
-        wipeSystemPromptOnEnterChat();
-      }
     }, true);
-
-    // 2) Hedef butona doğrudan dinleyici ekle (stopImmediatePropagation olsa bile capture ile yakalarız)
-    const clearBtn = document.getElementById('clear-chat');
-    if (clearBtn) {
-      clearBtn.setAttribute('type','button');
-      clearBtn.addEventListener('click', function(e){ e.preventDefault(); clearChatUI(); }, true); // capture=true
-    }
-
-    // Enter (Shift'siz) ile gönderimler için de koruma
-    const input = document.getElementById('user-input');
-    if (input) {
-      input.addEventListener('keydown', function(ev){
-        if (ev.key === 'Enter' && !ev.shiftKey) {
-          injectStealthDefaultOnce();
-        }
-      }, true);
-    }
-
-    // Kullanıcı sistem promptuna dokunduysa bir daha otomatik boşaltmayalım
-    const sys = document.getElementById('system-prompt');
-    if (sys) {
-      sys.addEventListener('input', ()=>{ sys.dataset.userTouched = '1'; });
-    }
   }
 
-  document.addEventListener('DOMContentLoaded', wireUp);
-})();
+  // Kullanıcı sistem promptuna dokunduysa bir daha otomatik boşaltmayalım
+  const sys = document.getElementById('system-prompt');
+  if (sys) {
+    sys.addEventListener('input', ()=>{ sys.dataset.userTouched = '1'; });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', wireUp);


### PR DESCRIPTION
## Summary
- export DEFAULT_SYSTEM_PROMPT from system-prompt-helpers for reuse
- import DEFAULT_SYSTEM_PROMPT in default-system-prompt module and drop duplicate constant
- load prompt scripts as ES modules in index.html

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b56f6419688328aca33cd6cce89f6f